### PR TITLE
Add Tkinter property sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,19 @@
 > Click the <kbd>Use this template</kbd> button and clone it in IntelliJ IDEA.
 
 <!-- Plugin description -->
-**IntelliJ Platform Plugin Template** is a repository that provides a pure template to make it easier to create a new plugin project (check the [Creating a repository from a template][gh:template] article).
-
-The main goal of this template is to speed up the setup phase of plugin development for both new and experienced developers by preconfiguring the project scaffold and CI, linking to the proper documentation pages, and keeping everything organized.
-
-[gh:template]: https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template
+Visual Tkinter Designer adds a WYSIWYG editor for building Tkinter dialogs inside IntelliJ IDEA 2024.3.
+It provides a design surface with drag and resize support, a floating palette for common widgets
+including menus, menubuttons, paned windows and scrollbars, and a property panel for editing widget
+attributes. Clicking the dialog background reveals dialog properties such as size. Multiple widgets can
+be selected, aligned or grouped inside frames. Designs support undo/redo history, keyboard shortcuts
+and grid snapping with rulers and overlay measurements. Containers may use place, pack or grid geometry
+managers. A hierarchy tree helps select nested widgets while a font/style inspector offers color and
+font pickers. Components snap to guides and can be distributed evenly. Projects may contain several
+dialogs and reference image resources with paths stored relative to the project. Event snippets are available for
+callbacks and you can choose the Python interpreter used for preview. `.tkdesign` files open in a custom diff viewer
+that lists changed widgets and properties. Localization keys may be assigned to text and translations are saved
+alongside the project. You can preview the generated Python or import existing scripts, and save
+work in `.tkdesign` JSON files which can easily be version controlled and recreate the dialog exactly in Tkinter.
 <!-- Plugin description end -->
 
 If you're still not quite sure what this is all about, read our introduction: [What is the IntelliJ Platform?][docs:intro]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ repositories {
 dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.opentest4j)
+    implementation(libs.gson)
 
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,12 @@ pluginRepositoryUrl = https://github.com/JetBrains/intellij-platform-plugin-temp
 pluginVersion = 2.1.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 242
-pluginUntilBuild = 252.*
+pluginSinceBuild = 243
+pluginUntilBuild = 253.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2024.2.5
+platformVersion = 2024.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ qodana = "2024.3.4"
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
+gson = { group = "com.google.code.gson", name = "gson", version = "2.10.1" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }

--- a/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/TkdesignDiffTool.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/TkdesignDiffTool.kt
@@ -1,0 +1,57 @@
+package org.jetbrains.plugins.template.tkdesigner
+
+import com.google.gson.Gson
+import com.intellij.diff.DiffContext
+import com.intellij.diff.FrameDiffTool
+import com.intellij.diff.requests.ContentDiffRequest
+import com.intellij.diff.requests.DiffRequest
+import com.intellij.util.ui.UIUtil
+import java.awt.BorderLayout
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.JTextArea
+
+/** Simple diff viewer for .tkdesign files highlighting changed properties. */
+class TkdesignDiffTool : FrameDiffTool {
+    override fun getName(): String = "Tkdesign Diff"
+
+    override fun canShow(context: DiffContext, request: DiffRequest): Boolean {
+        if (request !is ContentDiffRequest) return false
+        val files = request.contents.mapNotNull { (it as? com.intellij.diff.contents.FileContent)?.file }
+        return files.size == 2 && files.all { it.extension == "tkdesign" }
+    }
+
+    override fun createComponent(context: DiffContext, request: DiffRequest): FrameDiffTool.DiffViewer {
+        request as ContentDiffRequest
+        val leftText = (request.contents[0] as? com.intellij.diff.contents.DocumentContent)?.document?.text ?: ""
+        val rightText = (request.contents[1] as? com.intellij.diff.contents.DocumentContent)?.document?.text ?: ""
+        val diff = buildDiff(leftText, rightText)
+        val area = JTextArea(diff).apply { isEditable = false; background = UIUtil.getPanelBackground() }
+        val panel = JPanel().apply { layout = java.awt.BorderLayout(); add(area, java.awt.BorderLayout.CENTER) }
+        return object : FrameDiffTool.DiffViewer {
+            override fun getComponent(): JComponent = panel
+            override fun getPreferredFocusedComponent(): JComponent? = null
+            override fun init() = FrameDiffTool.ToolbarComponents()
+            override fun dispose() {}
+        }
+    }
+
+    private fun buildDiff(left: String, right: String): String {
+        val gson = Gson()
+        val leftMap = gson.fromJson(left, Map::class.java) as Map<String, Any?>
+        val rightMap = gson.fromJson(right, Map::class.java) as Map<String, Any?>
+        return buildString { compareMaps(leftMap, rightMap, "") }
+    }
+
+    private fun StringBuilder.compareMaps(a: Map<String, Any?>, b: Map<String, Any?>, prefix: String) {
+        for (key in a.keys union b.keys) {
+            val av = a[key]
+            val bv = b[key]
+            if (av is Map<*, *> && bv is Map<*, *>) {
+                compareMaps(av as Map<String, Any?>, bv as Map<String, Any?>, "$prefix$key.")
+            } else if (av != bv) {
+                appendLine("$prefix$key: $av -> $bv")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/TkinterDesignerToolWindowFactory.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/TkinterDesignerToolWindowFactory.kt
@@ -1,0 +1,194 @@
+package org.jetbrains.plugins.template.tkdesigner
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.content.ContentFactory
+import org.jetbrains.plugins.template.tkdesigner.model.DialogModel
+import org.jetbrains.plugins.template.tkdesigner.model.DesignProject
+import org.jetbrains.plugins.template.tkdesigner.ui.ComponentPalette
+import org.jetbrains.plugins.template.tkdesigner.ui.DesignAreaPanel
+import org.jetbrains.plugins.template.tkdesigner.ui.PropertyPanel
+import org.jetbrains.plugins.template.tkdesigner.ui.HierarchyPanel
+import java.awt.BorderLayout
+import kotlin.io.path.createTempFile
+import javax.swing.JButton
+import javax.swing.JPanel
+import javax.swing.JSplitPane
+
+class TkinterDesignerToolWindowFactory : ToolWindowFactory {
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val projectModel = DesignProject().apply { basePath = project.basePath ?: "" }
+        var model = projectModel.activeDialog
+        val designArea = DesignAreaPanel(model)
+        val palette = ComponentPalette(designArea)
+        val properties = PropertyPanel(designArea, projectModel).apply { isVisible = false }
+        val hierarchy = HierarchyPanel(designArea)
+        designArea.selectionListener = {
+            properties.bind(it)
+            properties.isVisible = it != null
+            hierarchy.refresh()
+        }
+        designArea.dialogListener = {
+            properties.bindDialog(it)
+            properties.isVisible = true
+            hierarchy.refresh()
+        }
+
+        val panel = JPanel(BorderLayout())
+        val centerSplit = JSplitPane(JSplitPane.HORIZONTAL_SPLIT, JBScrollPane(designArea), properties)
+        centerSplit.resizeWeight = 0.7
+        val split = JSplitPane(JSplitPane.HORIZONTAL_SPLIT, JBScrollPane(hierarchy), centerSplit)
+        split.resizeWeight = 0.2
+        panel.add(split, BorderLayout.CENTER)
+        val loadButton = JButton("Load")
+        val saveButton = JButton("Save")
+        val genButton = JButton("Generate")
+        val previewButton = JButton("Preview")
+        val undoButton = JButton("Undo")
+        val redoButton = JButton("Redo")
+        val alignLeft = JButton("Align Left")
+        val alignRight = JButton("Align Right")
+        val alignTop = JButton("Align Top")
+        val alignBottom = JButton("Align Bottom")
+        val centerH = JButton("Center H")
+        val centerV = JButton("Center V")
+        val distH = JButton("Distribute H")
+        val distV = JButton("Distribute V")
+        val dialogChooser = javax.swing.JComboBox<String>().apply { addItem("Dialog 1") }
+        val addDialog = JButton("+")
+        val pythonField = JBTextField(projectModel.pythonInterpreter, 10)
+        val group = JButton("Group")
+        val importButton = JButton("Import Python")
+        val top = JPanel().apply {
+            add(javax.swing.JLabel("Python:"))
+            add(pythonField)
+            add(dialogChooser)
+            add(addDialog)
+            add(loadButton)
+            add(saveButton)
+            add(genButton)
+            add(previewButton)
+            add(importButton)
+            add(undoButton)
+            add(redoButton)
+            add(alignLeft)
+            add(alignRight)
+            add(alignTop)
+            add(alignBottom)
+            add(centerH)
+            add(centerV)
+            add(distH)
+            add(distV)
+            add(group)
+        }
+        panel.add(top, BorderLayout.NORTH)
+
+        loadButton.addActionListener {
+            val path = Messages.showInputDialog(project, "Enter path to load", "Load", null)
+            path?.let {
+                val f = java.io.File(it)
+                if (f.exists()) {
+                    val text = f.readText()
+                    val proj = try { DesignProject.fromJson(text) } catch (_: Exception) { null }
+                    if (proj != null) {
+                        projectModel.dialogs.clear(); projectModel.dialogs.addAll(proj.dialogs)
+                        projectModel.resources.clear(); projectModel.resources.addAll(proj.resources)
+                        model = projectModel.activeDialog
+                        dialogChooser.removeAllItems()
+                        projectModel.dialogs.indices.forEach { dialogChooser.addItem("Dialog ${it+1}") }
+                        designArea.loadModel(model)
+                    } else {
+                        val loaded = DialogModel.fromJson(text)
+                        projectModel.dialogs.clear(); projectModel.dialogs.add(loaded)
+                        dialogChooser.removeAllItems(); dialogChooser.addItem("Dialog 1")
+                        model = loaded
+                        designArea.loadModel(loaded)
+                    }
+                }
+            }
+        }
+
+        saveButton.addActionListener {
+            properties.applyChanges()
+            val path = Messages.showInputDialog(project, "Enter path to save", "Save", null)
+            path?.let {
+                val f = java.io.File(if (it.endsWith(".tkdesign")) it else "$it.tkdesign")
+                f.writeText(projectModel.toJson())
+            }
+        }
+
+        genButton.addActionListener {
+            properties.applyChanges()
+            val pythonCode = TkinterGenerator.generate(designArea.model, projectModel.translations)
+            val clipboard = com.intellij.openapi.ide.CopyPasteManager.getInstance()
+            clipboard.setContents(java.awt.datatransfer.StringSelection(pythonCode))
+            Messages.showInfoMessage(project, "Python code copied to clipboard", "Generated")
+        }
+
+        previewButton.addActionListener {
+            properties.applyChanges()
+            projectModel.pythonInterpreter = pythonField.text
+            val code = TkinterGenerator.generate(designArea.model, projectModel.translations)
+            try {
+                val tmp = kotlin.io.path.createTempFile("preview", ".py").toFile()
+                tmp.writeText(code)
+                Runtime.getRuntime().exec(arrayOf(projectModel.pythonInterpreter, tmp.absolutePath))
+            } catch (e: Exception) {
+                Messages.showErrorDialog(project, e.message, "Preview failed")
+            }
+        }
+
+        undoButton.addActionListener { designArea.undo() }
+        redoButton.addActionListener { designArea.redo() }
+        alignLeft.addActionListener { designArea.alignLeft() }
+        alignRight.addActionListener { designArea.alignRight() }
+        alignTop.addActionListener { designArea.alignTop() }
+        alignBottom.addActionListener { designArea.alignBottom() }
+        centerH.addActionListener { designArea.alignCenterHorizontal() }
+        centerV.addActionListener { designArea.alignCenterVertical() }
+        distH.addActionListener { designArea.distributeHorizontal() }
+        distV.addActionListener { designArea.distributeVertical() }
+        group.addActionListener { designArea.groupSelected() }
+        importButton.addActionListener {
+            val path = Messages.showInputDialog(project, "Python file to import", "Import", null)
+            path?.let {
+                val f = java.io.File(it)
+                if (f.exists()) {
+                    val loaded = TkinterImporter.importScript(f.readText())
+                    projectModel.dialogs.clear(); projectModel.dialogs.add(loaded)
+                    dialogChooser.removeAllItems(); dialogChooser.addItem("Dialog 1")
+                    model = loaded
+                    designArea.loadModel(loaded)
+                }
+            }
+        }
+
+        dialogChooser.addActionListener {
+            val idx = dialogChooser.selectedIndex
+            if (idx >= 0 && idx < projectModel.dialogs.size) {
+                model = projectModel.dialogs[idx]
+                projectModel.current = idx
+                designArea.loadModel(model)
+            }
+        }
+
+        addDialog.addActionListener {
+            val newDialog = DialogModel()
+            projectModel.dialogs.add(newDialog)
+            dialogChooser.addItem("Dialog ${projectModel.dialogs.size}")
+            dialogChooser.selectedIndex = projectModel.dialogs.size - 1
+        }
+
+        val content = ContentFactory.getInstance().createContent(panel, null, false)
+        toolWindow.contentManager.addContent(content)
+
+        palette.setLocation(200, 200)
+        palette.isVisible = true
+    }
+
+    override fun shouldBeAvailable(project: Project) = true
+}

--- a/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/TkinterGenerator.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/TkinterGenerator.kt
@@ -1,0 +1,62 @@
+package org.jetbrains.plugins.template.tkdesigner
+
+import org.jetbrains.plugins.template.tkdesigner.model.DialogModel
+import org.jetbrains.plugins.template.tkdesigner.model.WidgetModel
+
+/**
+ * Generates Python Tkinter code from a [DialogModel].
+ */
+object TkinterGenerator {
+    fun generate(model: DialogModel, translations: Map<String, Map<String, String>> = emptyMap()): String {
+        val builder = StringBuilder()
+        builder.appendLine("import tkinter as tk")
+        if (translations.isNotEmpty()) {
+            val json = com.google.gson.Gson().toJson(translations)
+            builder.appendLine("translations = $json")
+            builder.appendLine("lang = 'en'")
+            builder.appendLine("def tr(key): return translations.get(lang, {}).get(key, key)")
+        }
+        builder.appendLine()
+        builder.appendLine("root = tk.Tk()")
+        builder.appendLine("root.geometry(\"${model.width}x${model.height}\")")
+        val rootManager = model.layout
+        fun renderWidget(w: WidgetModel, parent: String, index: Int) {
+            val name = "${w.type.lowercase()}_${index}"
+            val textExpr = w.properties["textKey"]?.let { "tr(\"$it\")" } ?: "\"${w.properties["text"] ?: ""}\""
+            when (w.type) {
+                "Button" -> builder.appendLine("$name = tk.Button($parent, text=$textExpr)")
+                "Label" -> builder.appendLine("$name = tk.Label($parent, text=$textExpr)")
+                "Entry" -> builder.appendLine("$name = tk.Entry($parent)")
+                "Text" -> builder.appendLine("$name = tk.Text($parent)")
+                "Frame" -> builder.appendLine("$name = tk.Frame($parent)")
+                "Canvas" -> builder.appendLine("$name = tk.Canvas($parent)")
+                "Menu" -> builder.appendLine("$name = tk.Menu($parent)")
+                "Menubutton" -> builder.appendLine("$name = tk.Menubutton($parent, text=$textExpr)")
+                "PanedWindow" -> builder.appendLine("$name = tk.PanedWindow($parent)")
+                "Scrollbar" -> builder.appendLine("$name = tk.Scrollbar($parent)")
+                "Checkbutton" -> builder.appendLine("$name = tk.Checkbutton($parent, text=$textExpr)")
+                "Radiobutton" -> builder.appendLine("$name = tk.Radiobutton($parent, text=$textExpr)")
+                "Listbox" -> builder.appendLine("$name = tk.Listbox($parent)")
+                "Scale" -> builder.appendLine("$name = tk.Scale($parent, from_=0, to=100)")
+                "Spinbox" -> builder.appendLine("$name = tk.Spinbox($parent, from_=0, to=10)")
+            }
+            w.properties["image"]?.let {
+                builder.appendLine("${name}_img = tk.PhotoImage(file=r'${it}')")
+                builder.appendLine("$name.configure(image=${name}_img)")
+            }
+            when ((w.parent?.layout ?: rootManager)) {
+                "pack" -> builder.appendLine("$name.pack()")
+                "grid" -> builder.appendLine("$name.grid(row=${w.properties["row"] ?: 0}, column=${w.properties["column"] ?: 0})")
+                else -> builder.appendLine("$name.place(x=${w.x}, y=${w.y}, width=${w.width}, height=${w.height})")
+            }
+            for ((event, cb) in w.events) {
+                builder.appendLine("$name.bind(\"$event\", lambda e: $cb())")
+            }
+            w.children.forEachIndexed { i, child -> renderWidget(child, name, i) }
+        }
+
+        model.widgets.forEachIndexed { i, w -> renderWidget(w, "root", i) }
+        builder.appendLine("root.mainloop()")
+        return builder.toString()
+    }
+}

--- a/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/TkinterImporter.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/TkinterImporter.kt
@@ -1,0 +1,41 @@
+package org.jetbrains.plugins.template.tkdesigner
+
+import org.jetbrains.plugins.template.tkdesigner.model.DialogModel
+import org.jetbrains.plugins.template.tkdesigner.model.WidgetModel
+
+/** Simple importer that parses basic Tkinter scripts with .place geometry. */
+object TkinterImporter {
+    fun importScript(text: String): DialogModel {
+        val model = DialogModel()
+        val widgetMap = mutableMapOf<String, WidgetModel>()
+        val createRegex = Regex("""(\w+)\s*=\s*tk\.(\w+)\(""")
+        val placeRegex = Regex("""(\w+)\.place\(.*?x=(\d+).*?y=(\d+).*?(width=(\d+))?.*?(height=(\d+))?.*?\)""")
+        val geometryRegex = Regex("""root.geometry\("(\d+)x(\d+)"\)""")
+        geometryRegex.find(text)?.let { m ->
+            model.width = m.groupValues[1].toInt()
+            model.height = m.groupValues[2].toInt()
+        }
+        text.lines().forEach { line ->
+            createRegex.find(line)?.let { m ->
+                val varName = m.groupValues[1]
+                val type = m.groupValues[2]
+                widgetMap[varName] = WidgetModel(type, 0, 0, 80, 30)
+            }
+            placeRegex.find(line)?.let { m ->
+                val varName = m.groupValues[1]
+                val x = m.groupValues[2].toInt()
+                val y = m.groupValues[3].toInt()
+                val width = m.groupValues.getOrNull(5)?.toIntOrNull() ?: 80
+                val height = m.groupValues.getOrNull(7)?.toIntOrNull() ?: 30
+                widgetMap[varName]?.apply {
+                    this.x = x
+                    this.y = y
+                    this.width = width
+                    this.height = height
+                    model.widgets.add(this)
+                }
+            }
+        }
+        return model
+    }
+}

--- a/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/model/DesignProject.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/model/DesignProject.kt
@@ -1,0 +1,24 @@
+package org.jetbrains.plugins.template.tkdesigner.model
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+/** Root of a .tkdesign project containing multiple dialogs and resources. */
+data class DesignProject(
+    val dialogs: MutableList<DialogModel> = mutableListOf(DialogModel()),
+    var current: Int = 0,
+    val resources: MutableSet<String> = mutableSetOf(),
+    var pythonInterpreter: String = "python",
+    val translations: MutableMap<String, MutableMap<String, String>> = mutableMapOf(),
+    @Transient var basePath: String = ""
+) {
+    fun toJson(): String = Gson().toJson(this)
+
+    val activeDialog: DialogModel
+        get() = dialogs[current]
+
+    companion object {
+        fun fromJson(json: String): DesignProject =
+            Gson().fromJson(json, object : TypeToken<DesignProject>() {}.type)
+    }
+}

--- a/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/model/DialogModel.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/model/DialogModel.kt
@@ -1,0 +1,21 @@
+package org.jetbrains.plugins.template.tkdesigner.model
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+/**
+ * Model representing a dialog composed of Tkinter widgets.
+ */
+data class DialogModel(
+    var width: Int = 400,
+    var height: Int = 300,
+    var layout: String = "place",
+    val widgets: MutableList<WidgetModel> = mutableListOf()
+) {
+    fun toJson(): String = Gson().toJson(this)
+
+    companion object {
+        fun fromJson(json: String): DialogModel =
+            Gson().fromJson(json, object : TypeToken<DialogModel>() {}.type)
+    }
+}

--- a/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/model/WidgetModel.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/model/WidgetModel.kt
@@ -1,0 +1,17 @@
+package org.jetbrains.plugins.template.tkdesigner.model
+
+/**
+ * Represents a single widget in the designer.
+ */
+data class WidgetModel(
+    val type: String,
+    var x: Int,
+    var y: Int,
+    var width: Int,
+    var height: Int,
+    var layout: String = "place",
+    val properties: MutableMap<String, String> = mutableMapOf(),
+    val events: MutableMap<String, String> = mutableMapOf(),
+    val children: MutableList<WidgetModel> = mutableListOf(),
+    @Transient var parent: WidgetModel? = null
+)

--- a/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/ui/ComponentPalette.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/ui/ComponentPalette.kt
@@ -1,0 +1,44 @@
+package org.jetbrains.plugins.template.tkdesigner.ui
+
+import java.awt.FlowLayout
+import javax.swing.JButton
+import javax.swing.JDialog
+
+/**
+ * Floating palette with Tkinter widgets.
+ */
+class ComponentPalette(private val design: DesignAreaPanel) : JDialog() {
+    init {
+        title = "Widgets"
+        layout = FlowLayout()
+        isAlwaysOnTop = true
+        isResizable = false
+
+        val types = listOf(
+            "Button",
+            "Label",
+            "Entry",
+            "Text",
+            "Frame",
+            "Canvas",
+            "Menu",
+            "Menubutton",
+            "PanedWindow",
+            "Scrollbar",
+            "Checkbutton",
+            "Radiobutton",
+            "Listbox",
+            "Scale",
+            "Spinbox"
+        )
+        for (t in types) {
+            add(createButton(t))
+        }
+
+        pack()
+    }
+
+    private fun createButton(type: String): JButton = JButton(type).apply {
+        addActionListener { design.beginAddWidget(type) }
+    }
+}

--- a/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/ui/DesignAreaPanel.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/ui/DesignAreaPanel.kt
@@ -1,0 +1,507 @@
+package org.jetbrains.plugins.template.tkdesigner.ui
+
+import org.jetbrains.plugins.template.tkdesigner.model.DialogModel
+import org.jetbrains.plugins.template.tkdesigner.model.WidgetModel
+import java.awt.*
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.JComponent
+import javax.swing.JLayeredPane
+
+/**
+ * Panel used as design surface for Tkinter dialogs.
+ */
+class DesignAreaPanel(var model: DialogModel) : JLayeredPane() {
+
+    var selectionListener: ((WidgetModel?) -> Unit)? = null
+    var dialogListener: ((DialogModel) -> Unit)? = null
+
+    private val designWidgets = mutableListOf<DesignWidget>()
+
+    private val selectedWidgets = mutableSetOf<DesignWidget>()
+
+    private val history = mutableListOf<DialogModel>()
+    private var historyIndex = -1
+
+    var gridSize = 10
+
+    private var pendingAddType: String? = null
+    private var dragWidget: DesignWidget? = null
+    private var dragStartX = 0
+    private var dragStartY = 0
+    private var dragInitial: Map<DesignWidget, Rectangle> = emptyMap()
+    private var overlay: String? = null
+    private var guideX: Int? = null
+    private var guideY: Int? = null
+
+    var selected: DesignWidget? = null
+        private set
+
+    override fun paintComponent(g: Graphics) {
+        super.paintComponent(g)
+        g.color = Color.LIGHT_GRAY
+        var x = 0
+        while (x < width) {
+            g.drawLine(x, 0, x, height)
+            x += gridSize
+        }
+        var y = 0
+        while (y < height) {
+            g.drawLine(0, y, width, y)
+            y += gridSize
+        }
+        g.color = Color.DARK_GRAY
+        var rx = 0
+        while (rx < width) {
+            g.drawString(rx.toString(), rx + 2, 10)
+            rx += 50
+        }
+        var ry = 0
+        while (ry < height) {
+            g.drawString(ry.toString(), 2, ry + 20)
+            ry += 50
+        }
+        overlay?.let {
+            g.color = Color.BLACK
+            g.drawString(it, 10, height - 10)
+        }
+        guideX?.let {
+            g.color = Color.RED
+            g.drawLine(it, 0, it, height)
+        }
+        guideY?.let {
+            g.color = Color.RED
+            g.drawLine(0, it, width, it)
+        }
+    }
+
+    init {
+        layout = null
+        background = Color.WHITE
+        preferredSize = Dimension(model.width, model.height)
+        isOpaque = true
+        addMouseListener(object : MouseAdapter() {
+            override fun mousePressed(e: MouseEvent) {
+                if (pendingAddType != null && e.button == MouseEvent.BUTTON1) {
+                    val m = WidgetModel(pendingAddType!!, e.x, e.y, 1, 1)
+                    val comp = createComponent(m)
+                    val dw = DesignWidget(m, comp)
+                    addWidget(dw, attachListeners = false, recordHistory = false)
+                    dragWidget = dw
+                    dragStartX = e.x
+                    dragStartY = e.y
+                    overlay = null
+                    guideX = null
+                    guideY = null
+                } else if (e.button == MouseEvent.BUTTON1) {
+                    val clicked = designWidgets.findLast { it.component.bounds.contains(e.point) }
+                    if (clicked != null) {
+                        if (e.isShiftDown) {
+                            if (selectedWidgets.contains(clicked)) selectedWidgets.remove(clicked) else selectedWidgets.add(clicked)
+                        } else {
+                            selectedWidgets.clear(); selectedWidgets.add(clicked)
+                        }
+                        selected = clicked
+                        selectionListener?.invoke(clicked.model)
+                        dragInitial = selectedWidgets.associateWith { it.component.bounds }
+                        dragStartX = e.x
+                        dragStartY = e.y
+                        overlay = null
+                    } else {
+                        selectedWidgets.clear();
+                        selected = null
+                        selectionListener?.invoke(null)
+                        dialogListener?.invoke(model)
+                    }
+                }
+            }
+
+            override fun mouseReleased(e: MouseEvent) {
+                if (dragWidget != null) {
+                    installListeners(dragWidget!!)
+                    selectedWidgets.clear();
+                    selected = dragWidget
+                    selectedWidgets.add(dragWidget!!)
+                    selectionListener?.invoke(dragWidget!!.model)
+                    dragWidget = null
+                    pendingAddType = null
+                    pushHistory()
+                    overlay = null
+                    guideX = null
+                    guideY = null
+                }
+            }
+        })
+
+        addMouseMotionListener(object : MouseAdapter() {
+            override fun mouseDragged(e: MouseEvent) {
+                dragWidget?.let { widget ->
+                    val x1 = e.x
+                    val y1 = e.y
+                    val nx = snap(minOf(x1, dragStartX))
+                    val ny = snap(minOf(y1, dragStartY))
+                    val nw = snap(kotlin.math.abs(x1 - dragStartX))
+                    val nh = snap(kotlin.math.abs(y1 - dragStartY))
+                    var ax = nx
+                    var ay = ny
+                    guideX = null; guideY = null
+                    for (dw in designWidgets) {
+                        if (dw === widget) continue
+                        if (kotlin.math.abs(nx - dw.component.x) < 5) { ax = dw.component.x; guideX = ax }
+                        if (kotlin.math.abs(ny - dw.component.y) < 5) { ay = dw.component.y; guideY = ay }
+                    }
+                    widget.component.setBounds(ax, ay, nw, nh)
+                    widget.model.x = ax
+                    widget.model.y = ay
+                    widget.model.width = nw
+                    widget.model.height = nh
+                    overlay = "${nw}x$nh"
+                    repaint()
+                }
+            }
+        })
+
+        val im = inputMap
+        val am = actionMap
+        im.put(javax.swing.KeyStroke.getKeyStroke("control Z"), "undo")
+        im.put(javax.swing.KeyStroke.getKeyStroke("control Y"), "redo")
+        im.put(javax.swing.KeyStroke.getKeyStroke("control C"), "copy")
+        im.put(javax.swing.KeyStroke.getKeyStroke("control V"), "paste")
+        im.put(javax.swing.KeyStroke.getKeyStroke("control D"), "dup")
+        am.put("undo", object : javax.swing.AbstractAction() { override fun actionPerformed(e: java.awt.event.ActionEvent?) { undo() } })
+        am.put("redo", object : javax.swing.AbstractAction() { override fun actionPerformed(e: java.awt.event.ActionEvent?) { redo() } })
+        am.put("copy", object : javax.swing.AbstractAction() { override fun actionPerformed(e: java.awt.event.ActionEvent?) { copySelection() } })
+        am.put("paste", object : javax.swing.AbstractAction() { override fun actionPerformed(e: java.awt.event.ActionEvent?) { paste() } })
+        am.put("dup", object : javax.swing.AbstractAction() { override fun actionPerformed(e: java.awt.event.ActionEvent?) { duplicate() } })
+    }
+
+    fun beginAddWidget(type: String) {
+        pendingAddType = type
+    }
+
+    fun addWidget(widget: DesignWidget, attachListeners: Boolean = true, recordHistory: Boolean = true): DesignWidget {
+        if (widget.model.parent == null) {
+            model.widgets.add(widget.model)
+            add(widget.component, Integer(0))
+        } else {
+            getDesignWidget(widget.model.parent!!)?.component?.add(widget.component)
+            widget.model.parent!!.children.add(widget.model)
+        }
+        designWidgets.add(widget)
+        widget.component.setBounds(widget.model.x, widget.model.y, widget.model.width, widget.model.height)
+        revalidate()
+        repaint()
+        if (attachListeners) installListeners(widget)
+        if (recordHistory) pushHistory()
+        return widget
+    }
+
+    fun addWidget(model: WidgetModel, attachListeners: Boolean = true, recordHistory: Boolean = true) {
+        val comp = createComponent(model)
+        val dw = DesignWidget(model, comp)
+        addWidget(dw, attachListeners, recordHistory)
+        model.children.forEach { child ->
+            child.parent = model
+            addWidget(child, attachListeners, recordHistory)
+        }
+    }
+
+    fun getDesignWidget(model: WidgetModel): DesignWidget? =
+        designWidgets.find { it.model === model }
+
+    fun selectModel(model: WidgetModel) {
+        val dw = getDesignWidget(model) ?: return
+        selectedWidgets.clear()
+        selected = dw
+        selectedWidgets.add(dw)
+        selectionListener?.invoke(model)
+        repaint()
+    }
+
+    fun clear() {
+        removeAll()
+        designWidgets.clear()
+        model.widgets.clear()
+        selected = null
+        selectionListener?.invoke(null)
+        repaint()
+    }
+
+    fun loadModel(newModel: DialogModel) {
+        clear()
+        model = newModel
+        preferredSize = Dimension(model.width, model.height)
+        for (w in model.widgets) {
+            addWidget(w, recordHistory = false)
+        }
+    }
+
+    private fun snap(value: Int): Int = (value / gridSize) * gridSize
+
+    private fun pushHistory() {
+        if (historyIndex < history.size - 1) {
+            history.subList(historyIndex + 1, history.size).clear()
+        }
+        fun cloneWidget(w: WidgetModel): WidgetModel = w.copy(
+            properties = w.properties.toMutableMap(),
+            events = w.events.toMutableMap(),
+            children = w.children.map { cloneWidget(it) }.toMutableList(),
+            parent = null
+        )
+
+        val copy = model.copy(
+            width = model.width,
+            height = model.height,
+            widgets = model.widgets.map { cloneWidget(it) }.toMutableList()
+        )
+        history.add(copy)
+        historyIndex = history.size - 1
+    }
+
+    fun undo() {
+        if (historyIndex > 0) {
+            historyIndex--
+            loadModel(history[historyIndex])
+        }
+    }
+
+    fun redo() {
+        if (historyIndex < history.size - 1) {
+            historyIndex++
+            loadModel(history[historyIndex])
+        }
+    }
+
+    private fun createComponent(model: WidgetModel): JComponent = when (model.type) {
+        "Button" -> javax.swing.JButton(model.properties["text"] ?: "Button")
+        "Label" -> javax.swing.JLabel(model.properties["text"] ?: "Label")
+        "Entry" -> javax.swing.JTextField()
+        "Text" -> javax.swing.JTextArea()
+        "Frame" -> javax.swing.JPanel().apply { border = javax.swing.BorderFactory.createLineBorder(Color.GRAY) }
+        "Canvas" -> javax.swing.JPanel().apply { background = Color.WHITE; border = javax.swing.BorderFactory.createLineBorder(Color.GRAY) }
+        "Checkbutton" -> javax.swing.JCheckBox(model.properties["text"] ?: "Check")
+        "Radiobutton" -> javax.swing.JRadioButton(model.properties["text"] ?: "Radio")
+        "Listbox" -> javax.swing.JList<String>()
+        "Scale" -> javax.swing.JSlider()
+        "Spinbox" -> javax.swing.JSpinner()
+        else -> javax.swing.JPanel()
+    }
+
+    private fun installListeners(widget: DesignWidget) {
+        val comp = widget.component
+        val listener = object : MouseAdapter() {
+            var dragOffsetX = 0
+            var dragOffsetY = 0
+            var resizing = false
+
+            override fun mousePressed(e: MouseEvent) {
+                if (!e.isShiftDown) selectedWidgets.clear()
+                selectedWidgets.add(widget)
+                selected = widget
+                selectionListener?.invoke(widget.model)
+                dragOffsetX = e.x
+                dragOffsetY = e.y
+                resizing = e.x >= comp.width - 10 && e.y >= comp.height - 10
+                dragInitial = selectedWidgets.associateWith { it.component.bounds }
+                overlay = null
+            }
+
+            override fun mouseDragged(e: MouseEvent) {
+                if (resizing) {
+                    val dx = snap(e.x) - dragOffsetX
+                    val dy = snap(e.y) - dragOffsetY
+                    selectedWidgets.forEach { w ->
+                        val start = dragInitial[w] ?: w.component.bounds
+                        val newW = snap(start.width + dx)
+                        val newH = snap(start.height + dy)
+                        w.component.setSize(newW, newH)
+                        w.model.width = newW
+                        w.model.height = newH
+                    }
+                    overlay = "${selected!!.component.width}x${selected!!.component.height}"
+                } else {
+                    val dx = snap(widget.component.x + e.x - dragOffsetX) - widget.component.x
+                    val dy = snap(widget.component.y + e.y - dragOffsetY) - widget.component.y
+                    selectedWidgets.forEach { w ->
+                        val start = dragInitial[w] ?: w.component.bounds
+                        val nx = snap(start.x + dx)
+                        val ny = snap(start.y + dy)
+                        w.component.setLocation(nx, ny)
+                        w.model.x = nx
+                        w.model.y = ny
+                    }
+                    overlay = "(${selected!!.component.x},${selected!!.component.y})"
+                }
+                repaint()
+            }
+
+            override fun mouseReleased(e: MouseEvent) {
+                pushHistory()
+                overlay = null
+                guideX = null
+                guideY = null
+            }
+        }
+        comp.addMouseListener(listener)
+        comp.addMouseMotionListener(listener)
+    }
+
+    fun refreshWidget(model: WidgetModel) {
+        designWidgets.find { it.model === model }?.let { widget ->
+            when (val c = widget.component) {
+                is javax.swing.JButton -> c.text = model.properties["text"] ?: "Button"
+                is javax.swing.JLabel -> c.text = model.properties["text"] ?: "Label"
+            }
+            widget.component.setBounds(model.x, model.y, model.width, model.height)
+            revalidate()
+            repaint()
+        }
+    }
+
+    fun alignLeft() {
+        if (selectedWidgets.isEmpty()) return
+        val x = selectedWidgets.minOf { it.component.x }
+        for (w in selectedWidgets) {
+            w.component.setLocation(x, w.component.y)
+            w.model.x = x
+        }
+        pushHistory()
+        repaint()
+    }
+
+    fun alignTop() {
+        if (selectedWidgets.isEmpty()) return
+        val y = selectedWidgets.minOf { it.component.y }
+        for (w in selectedWidgets) {
+            w.component.setLocation(w.component.x, y)
+            w.model.y = y
+        }
+        pushHistory()
+        repaint()
+    }
+
+    fun alignRight() {
+        if (selectedWidgets.isEmpty()) return
+        val right = selectedWidgets.maxOf { it.component.x + it.component.width }
+        for (w in selectedWidgets) {
+            val x = right - w.component.width
+            w.component.setLocation(x, w.component.y)
+            w.model.x = x
+        }
+        pushHistory()
+        repaint()
+    }
+
+    fun alignBottom() {
+        if (selectedWidgets.isEmpty()) return
+        val bottom = selectedWidgets.maxOf { it.component.y + it.component.height }
+        for (w in selectedWidgets) {
+            val yb = bottom - w.component.height
+            w.component.setLocation(w.component.x, yb)
+            w.model.y = yb
+        }
+        pushHistory()
+        repaint()
+    }
+
+    fun alignCenterHorizontal() {
+        if (selectedWidgets.isEmpty()) return
+        val left = selectedWidgets.minOf { it.component.x }
+        val right = selectedWidgets.maxOf { it.component.x + it.component.width }
+        val center = (left + right) / 2
+        for (w in selectedWidgets) {
+            val x = center - w.component.width / 2
+            w.component.setLocation(x, w.component.y)
+            w.model.x = x
+        }
+        pushHistory()
+        repaint()
+    }
+
+    fun alignCenterVertical() {
+        if (selectedWidgets.isEmpty()) return
+        val top = selectedWidgets.minOf { it.component.y }
+        val bottom = selectedWidgets.maxOf { it.component.y + it.component.height }
+        val center = (top + bottom) / 2
+        for (w in selectedWidgets) {
+            val y = center - w.component.height / 2
+            w.component.setLocation(w.component.x, y)
+            w.model.y = y
+        }
+        pushHistory()
+        repaint()
+    }
+
+    fun distributeHorizontal() {
+        if (selectedWidgets.size < 3) return
+        val sorted = selectedWidgets.sortedBy { it.component.x }
+        val first = sorted.first()
+        val last = sorted.last()
+        val step = (last.component.x - first.component.x) / (sorted.size - 1)
+        sorted.forEachIndexed { i, dw ->
+            val x = first.component.x + i * step
+            dw.component.setLocation(x, dw.component.y)
+            dw.model.x = x
+        }
+        pushHistory(); repaint()
+    }
+
+    fun distributeVertical() {
+        if (selectedWidgets.size < 3) return
+        val sorted = selectedWidgets.sortedBy { it.component.y }
+        val first = sorted.first()
+        val last = sorted.last()
+        val step = (last.component.y - first.component.y) / (sorted.size - 1)
+        sorted.forEachIndexed { i, dw ->
+            val y = first.component.y + i * step
+            dw.component.setLocation(dw.component.x, y)
+            dw.model.y = y
+        }
+        pushHistory(); repaint()
+    }
+
+    private var clipboard: List<WidgetModel> = emptyList()
+
+    fun copySelection() {
+        clipboard = selectedWidgets.map { it.model.copy(properties = it.model.properties.toMutableMap(), events = it.model.events.toMutableMap()) }
+    }
+
+    fun paste() {
+        clipboard.forEach { m ->
+            val copy = m.copy(x = m.x + 10, y = m.y + 10, properties = m.properties.toMutableMap(), events = m.events.toMutableMap())
+            addWidget(copy)
+        }
+    }
+
+    fun duplicate() {
+        copySelection(); paste()
+    }
+
+    fun groupSelected() {
+        if (selectedWidgets.size < 2) return
+        val iterator = selectedWidgets.iterator()
+        val first = iterator.next()
+        val bounds = Rectangle(first.component.bounds)
+        iterator.forEachRemaining { bounds.add(it.component.bounds) }
+        val groupModel = WidgetModel("Frame", bounds.x, bounds.y, bounds.width, bounds.height)
+        addWidget(groupModel, recordHistory = false)
+        val groupWidget = designWidgets.last()
+        selectedWidgets.forEach { dw ->
+            remove(dw.component)
+            model.widgets.remove(dw.model)
+            designWidgets.remove(dw)
+            dw.model.x -= bounds.x
+            dw.model.y -= bounds.y
+            dw.model.parent = groupModel
+            groupModel.children.add(dw.model)
+            (groupWidget.component as java.awt.Container).add(dw.component)
+        }
+        selectedWidgets.clear()
+        selectedWidgets.add(groupWidget)
+        selected = groupWidget
+        pushHistory()
+        repaint()
+    }
+
+    data class DesignWidget(val model: WidgetModel, val component: JComponent)
+}

--- a/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/ui/HierarchyPanel.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/ui/HierarchyPanel.kt
@@ -1,0 +1,39 @@
+package org.jetbrains.plugins.template.tkdesigner.ui
+
+import org.jetbrains.plugins.template.tkdesigner.model.WidgetModel
+import java.awt.BorderLayout
+import javax.swing.JPanel
+import javax.swing.JScrollPane
+import javax.swing.JTree
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.DefaultTreeModel
+import javax.swing.tree.TreePath
+
+/** Panel showing a tree representation of the widget hierarchy. */
+class HierarchyPanel(private val design: DesignAreaPanel) : JPanel(BorderLayout()) {
+    private val rootNode = DefaultMutableTreeNode("Dialog")
+    private val treeModel = DefaultTreeModel(rootNode)
+    private val tree = JTree(treeModel)
+
+    init {
+        add(JScrollPane(tree), BorderLayout.CENTER)
+        tree.addTreeSelectionListener {
+            val path = it.path
+            val node = path.lastPathComponent as? DefaultMutableTreeNode
+            val model = node?.userObject as? WidgetModel
+            model?.let { m -> design.selectModel(m) }
+        }
+    }
+
+    fun refresh() {
+        rootNode.removeAllChildren()
+        design.model.widgets.forEach { addNode(rootNode, it) }
+        treeModel.reload()
+    }
+
+    private fun addNode(parent: DefaultMutableTreeNode, w: WidgetModel) {
+        val node = DefaultMutableTreeNode(w)
+        parent.add(node)
+        w.children.forEach { addNode(node, it) }
+    }
+}

--- a/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/ui/PropertyPanel.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/tkdesigner/ui/PropertyPanel.kt
@@ -1,0 +1,313 @@
+package org.jetbrains.plugins.template.tkdesigner.ui
+
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.components.JBCheckBox
+import javax.swing.JColorChooser
+import com.intellij.openapi.fileChooser.FileChooser
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
+import com.intellij.openapi.vfs.VfsUtil
+import org.jetbrains.plugins.template.tkdesigner.ui.DesignAreaPanel
+import org.jetbrains.plugins.template.tkdesigner.model.WidgetModel
+import org.jetbrains.plugins.template.tkdesigner.model.DialogModel
+import org.jetbrains.plugins.template.tkdesigner.model.DesignProject
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.beans.Introspector
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JComponent
+
+/**
+ * Panel showing properties of selected widget.
+ */
+import com.intellij.ui.DocumentAdapter
+import javax.swing.event.DocumentEvent
+
+class PropertyPanel(private val design: DesignAreaPanel, private val project: DesignProject) : JPanel(GridBagLayout()) {
+
+    private var fields = mutableMapOf<String, JComponent>()
+    private var currentWidget: WidgetModel? = null
+    private var currentDialog: DialogModel? = null
+    private var updating = false
+
+    fun bind(widget: WidgetModel?) {
+        removeAll()
+        fields.clear()
+        updating = true
+        currentDialog = null
+        currentWidget = widget
+
+        if (widget == null) {
+            revalidate()
+            repaint()
+            updating = false
+            return
+        }
+
+        val c = GridBagConstraints()
+        c.insets = java.awt.Insets(2, 2, 2, 2)
+        c.anchor = GridBagConstraints.NORTHWEST
+
+        var row = 0
+        fun addField(name: String, value: String, type: Class<*>? = null) {
+            val label = JLabel("$name:")
+            val comp: JComponent = when {
+                name == "layout" -> javax.swing.JComboBox(arrayOf("place", "pack", "grid")).apply {
+                    selectedItem = value
+                    addActionListener { applyChanges() }
+                }
+                type == java.awt.Color::class.java -> javax.swing.JButton().apply {
+                    background = try { java.awt.Color.decode(value) } catch (_: Exception) { java.awt.Color.white }
+                    addActionListener {
+                        val col = JColorChooser.showDialog(this, "Choose Color", background)
+                        col?.let { background = it; putClientProperty("value", String.format("#%06x", it.rgb and 0xffffff)) }
+                        applyChanges()
+                    }
+                    putClientProperty("value", value)
+                }
+                type == Boolean::class.java || type == java.lang.Boolean::class.java -> JBCheckBox().apply {
+                    isSelected = value.toBoolean()
+                    addChangeListener { applyChanges() }
+                }
+                name.contains("image", true) || name.contains("icon", true) || name.contains("file", true) -> JBTextField(value).also { field ->
+                    val browse = javax.swing.JButton("...")
+                    browse.addActionListener {
+                        val desc = FileChooserDescriptor(true, false, false, false, false, false)
+                        val file = FileChooser.chooseFile(desc, null, null)
+                        file?.let {
+                            val io = VfsUtil.virtualToIoFile(it)
+                            val path = if (project.basePath.isNotEmpty()) {
+                                val base = java.nio.file.Paths.get(project.basePath)
+                                base.relativize(io.toPath()).toString()
+                            } else io.absolutePath
+                            field.text = path
+                            project.resources.add(path)
+                            applyChanges()
+                        }
+                    }
+                    val panel = javax.swing.JPanel(java.awt.BorderLayout())
+                    panel.add(field, java.awt.BorderLayout.CENTER)
+                    panel.add(browse, java.awt.BorderLayout.EAST)
+                    fields[name] = field
+                    c.gridx = 0; c.gridy = row; add(label, c)
+                    c.gridx = 1; add(panel, c)
+                    row++
+                    return
+                }
+                name.contains("font", true) || type == java.awt.Font::class.java -> javax.swing.JButton(value).apply {
+                    putClientProperty("value", value)
+                    addActionListener {
+                        val fonts = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment().availableFontFamilyNames
+                        val combo = javax.swing.JComboBox(fonts)
+                        combo.selectedItem = value
+                        val size = javax.swing.JSpinner(javax.swing.SpinnerNumberModel(12, 6, 72, 1))
+                        val p = javax.swing.JPanel().apply { add(combo); add(size) }
+                        if (javax.swing.JOptionPane.showConfirmDialog(this, p, "Choose Font", javax.swing.JOptionPane.OK_CANCEL_OPTION) == javax.swing.JOptionPane.OK_OPTION) {
+                            val v = "${'$'}{combo.selectedItem}-${'$'}{size.value}"
+                            text = v
+                            putClientProperty("value", v)
+                            applyChanges()
+                        }
+                    }
+                }
+                name.startsWith("on_") -> JBTextField(value).also { field ->
+                    val snippets = mapOf("Print" to "print('Clicked')", "Close" to "root.destroy")
+                    val choose = javax.swing.JButton("...")
+                    choose.addActionListener {
+                        val opts = snippets.keys.toTypedArray()
+                        val sel = javax.swing.JOptionPane.showInputDialog(this, "Snippet", "Choose", javax.swing.JOptionPane.PLAIN_MESSAGE, null, opts, opts.first())
+                        if (sel != null) { field.text = snippets[sel] ?: ""; applyChanges() }
+                    }
+                    val panel = javax.swing.JPanel(java.awt.BorderLayout())
+                    panel.add(field, java.awt.BorderLayout.CENTER)
+                    panel.add(choose, java.awt.BorderLayout.EAST)
+                    fields[name] = field
+                    c.gridx = 0; c.gridy = row; add(label, c)
+                    c.gridx = 1; add(panel, c)
+                    row++
+                    return
+                }
+                name == "text" -> JBTextField(value).also { field ->
+                    val tButton = javax.swing.JButton("T")
+                    tButton.addActionListener {
+                        val key = javax.swing.JOptionPane.showInputDialog(this, "Translation key", widget.properties["textKey"] ?: "")
+                        if (key != null && key.isNotBlank()) {
+                            widget.properties["textKey"] = key
+                            val map = project.translations.getOrPut("en") { mutableMapOf() }
+                            map[key] = field.text
+                        }
+                    }
+                    val panel = javax.swing.JPanel(java.awt.BorderLayout())
+                    panel.add(field, java.awt.BorderLayout.CENTER)
+                    panel.add(tButton, java.awt.BorderLayout.EAST)
+                    fields[name] = field
+                    c.gridx = 0; c.gridy = row; add(label, c)
+                    c.gridx = 1; add(panel, c)
+                    row++
+                    return
+                }
+                else -> JBTextField(value)
+            }
+            fields[name] = comp
+            c.gridx = 0
+            c.gridy = row
+            add(label, c)
+            c.gridx = 1
+            add(comp, c)
+            row++
+        }
+
+        addField("x", widget.x.toString())
+        addField("y", widget.y.toString())
+        addField("width", widget.width.toString())
+        addField("height", widget.height.toString())
+        if (widget.children.isNotEmpty() || widget.type == "Frame" || widget.type == "Canvas") {
+            addField("layout", widget.layout)
+        }
+
+        val designWidget = design.getDesignWidget(widget)
+        designWidget?.let { dw ->
+            val beanInfo = Introspector.getBeanInfo(dw.component.javaClass)
+            for (pd in beanInfo.propertyDescriptors) {
+                if (pd.writeMethod != null && pd.readMethod != null && pd.name != "class") {
+                    val value = try { pd.readMethod.invoke(dw.component)?.toString() ?: "" } catch (e: Exception) { "" }
+                    if (!fields.containsKey(pd.name)) {
+                        addField(pd.name, value, pd.propertyType)
+                    }
+                }
+            }
+        }
+
+        for ((k, v) in widget.properties) {
+            if (k != "textKey" && !fields.containsKey(k)) addField(k, v)
+        }
+        for ((k, v) in widget.events) {
+            val name = "on_$k"
+            if (!fields.containsKey(name)) addField(name, v)
+        }
+
+        val listener = object : DocumentAdapter() {
+            override fun textChanged(e: DocumentEvent) { if (!updating) applyChanges() }
+        }
+        for (field in fields.values) {
+            when (field) {
+                is JBTextField -> field.document.addDocumentListener(listener)
+                is JBCheckBox -> field.addActionListener { if (!updating) applyChanges() }
+                is javax.swing.JButton -> {} // handled internally
+            }
+        }
+
+        updating = false
+        revalidate()
+        repaint()
+    }
+
+    fun bindDialog(dialog: DialogModel) {
+        removeAll()
+        fields.clear()
+        updating = true
+        currentWidget = null
+        currentDialog = dialog
+
+        val c = GridBagConstraints()
+        c.insets = java.awt.Insets(2, 2, 2, 2)
+        c.anchor = GridBagConstraints.NORTHWEST
+
+        var row = 0
+        fun addField(name: String, value: String) {
+            val label = JLabel("$name:")
+            val field = JBTextField(value)
+            fields[name] = field
+            c.gridx = 0
+            c.gridy = row
+            add(label, c)
+            c.gridx = 1
+            add(field, c)
+            row++
+        }
+
+        addField("width", dialog.width.toString())
+        addField("height", dialog.height.toString())
+        addField("layout", dialog.layout)
+
+        val listener = object : DocumentAdapter() {
+            override fun textChanged(e: DocumentEvent) { if (!updating) applyChanges() }
+        }
+        for (field in fields.values) {
+            if (field is JBTextField) field.document.addDocumentListener(listener)
+            if (field is JBCheckBox) field.addActionListener { if (!updating) applyChanges() }
+        }
+
+        updating = false
+        revalidate()
+        repaint()
+    }
+
+    fun applyChanges() {
+        currentWidget?.let { applyWidgetChanges(it) }
+        currentDialog?.let { applyDialogChanges(it) }
+    }
+
+    private fun applyWidgetChanges(widget: WidgetModel) {
+        val designWidget = design.getDesignWidget(widget)
+        fields.forEach { (name, field) ->
+            val value = when (field) {
+                is JBTextField -> field.text
+                is JBCheckBox -> field.isSelected.toString()
+                is javax.swing.JButton -> field.getClientProperty("value")?.toString() ?: ""
+                else -> ""
+            }
+            when (name) {
+                "x" -> value.toIntOrNull()?.let { widget.x = it; designWidget?.component?.setLocation(it, widget.y) }
+                "y" -> value.toIntOrNull()?.let { widget.y = it; designWidget?.component?.setLocation(widget.x, it) }
+                "width" -> value.toIntOrNull()?.let { widget.width = it; designWidget?.component?.setSize(it, widget.height) }
+                "height" -> value.toIntOrNull()?.let { widget.height = it; designWidget?.component?.setSize(widget.width, it) }
+                "layout" -> { widget.layout = value }
+                else -> {
+                    if (name.startsWith("on_")) {
+                        widget.events[name.substring(3)] = value
+                    } else {
+                        widget.properties[name] = value
+                    }
+                    designWidget?.let { dw ->
+                        val pd = Introspector.getBeanInfo(dw.component.javaClass).propertyDescriptors.find { it.name == name }
+                        if (pd?.writeMethod != null) {
+                            try {
+                                val converted = convertValue(value, pd.propertyType)
+                                pd.writeMethod.invoke(dw.component, converted)
+                            } catch (_: Exception) {
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        design.refreshWidget(widget)
+    }
+
+    private fun applyDialogChanges(dialog: DialogModel) {
+        fields.forEach { (name, field) ->
+            val value = when (field) {
+                is JBTextField -> field.text
+                is JBCheckBox -> field.isSelected.toString()
+                else -> ""
+            }
+            when (name) {
+                "width" -> value.toIntOrNull()?.let { dialog.width = it }
+                "height" -> value.toIntOrNull()?.let { dialog.height = it }
+                "layout" -> { dialog.layout = value }
+            }
+        }
+        design.preferredSize = java.awt.Dimension(dialog.width, dialog.height)
+        design.revalidate()
+        design.repaint()
+    }
+
+    private fun convertValue(value: String, type: Class<*>): Any? = when (type) {
+        Int::class.javaPrimitiveType, Int::class.javaObjectType -> value.toIntOrNull() ?: 0
+        Float::class.javaPrimitiveType, Float::class.javaObjectType -> value.toFloatOrNull() ?: 0f
+        Double::class.javaPrimitiveType, Double::class.javaObjectType -> value.toDoubleOrNull() ?: 0.0
+        Boolean::class.javaPrimitiveType, Boolean::class.javaObjectType -> value.toBoolean()
+        else -> value
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,8 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow factoryClass="org.jetbrains.plugins.template.toolWindow.MyToolWindowFactory" id="MyToolWindow"/>
+        <toolWindow factoryClass="org.jetbrains.plugins.template.tkdesigner.TkinterDesignerToolWindowFactory" id="TkinterDesigner" anchor="right"/>
+        <diffTool implementation="org.jetbrains.plugins.template.tkdesigner.TkdesignDiffTool"/>
         <postStartupActivity implementation="org.jetbrains.plugins.template.startup.MyProjectActivity" />
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
## Summary
- show property panel only when a widget is selected
- dynamically generate widget attributes using JavaBean introspection
- expose design widget lookup for updating components
- show dialog properties when background is clicked
- add grid snapping and undo/redo
- add alignment tools and grouping with multi-selection
- support importing Tkinter scripts and previewing generated code
- draw rulers and overlay when resizing
- document available palette widgets and preview support
- add geometry manager selection and hierarchy tree
- add font picker, resource browser, distribution commands
- allow multiple dialogs and configurable python path
- manage resources relative to the project and store translations
- support text localization and custom diff viewer for `.tkdesign` files

## Testing
- `./gradlew :build -x signPlugin --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6854550f23b483308c899edf101038dd